### PR TITLE
add "scope" to delegate param of pickConnection

### DIFF
--- a/source/vibe/db/postgresql/package.d
+++ b/source/vibe/db/postgresql/package.d
@@ -85,7 +85,7 @@ class PostgresClient
     /// reestablishing of connection by calling .reset()
     ///
     /// Returns: Value returned by delegate or void
-    T pickConnection(T)(T delegate(scope LockedConnection conn) dg)
+    T pickConnection(T)(scope T delegate(scope LockedConnection conn) dg)
     {
         logDebugV("get connection from the pool");
         scope conn = pool.lockConnection();


### PR DESCRIPTION
With `scope` added to delegate parameter, compilers (at least LDC) can allocate the delegate's closure on the stack. This would not matter if the method got inlined, but at least LDC does not inline pickConnection, probably because it generates too big LLVM IR code. Scoping the delegate at least avoids a heap allocation. Adding `scope` should not break any existing client code.